### PR TITLE
feat(identity): add batch nickname lookup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
           version: 1.66.0
 
       - name: Generate protobuf bindings
-        run: buf generate https://github.com/agynio/api.git#branch=main --path proto/agynio/api/identity/v1
+        run: buf generate https://github.com/agynio/api.git#branch=main --path proto/agynio/api/identity/v1 --path proto/agynio/api/authorization/v1
 
       - name: Run tests
         run: go test ./...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
           version: 1.66.0
 
       - name: Generate protobuf bindings
-        run: buf generate https://github.com/agynio/api.git#branch=main --path proto/agynio/api/identity/v1 --path proto/agynio/api/authorization/v1
+        run: buf generate https://github.com/agynio/api.git#commit=7326d1b87be7700a4bc175e5ce8150de3f46484c --path proto/agynio/api/identity/v1 --path proto/agynio/api/authorization/v1
 
       - name: Run tests
         run: go test ./...

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,6 @@
 ARG GO_VERSION=1.25
 ARG BUF_VERSION=1.66.0
 ARG BUF_INPUT=buf.build/agynio/api
-ARG BUF_PATH=agynio/api/identity/v1
 
 FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-alpine AS buf
 ARG BUF_VERSION
@@ -27,8 +26,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 
 COPY buf.gen.yaml buf.yaml ./
 ARG BUF_INPUT
-ARG BUF_PATH
-RUN buf generate ${BUF_INPUT} --path ${BUF_PATH}
+RUN buf generate ${BUF_INPUT} --path agynio/api/identity/v1 --path agynio/api/authorization/v1
 
 COPY . .
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ The Identity service registers identity IDs and their corresponding types.
 
 Architecture: [Identity](https://github.com/agynio/architecture/blob/main/architecture/identity.md)
 
+## Nickname Lookup Behavior
+
+`BatchGetNicknames` returns entries only for identities with nicknames; identity IDs without a nickname are omitted from the response.
+
 ## Local Development
 
 Full setup: [Local Development](https://github.com/agynio/architecture/blob/main/architecture/operations/local-development.md)

--- a/cmd/identity-service/main.go
+++ b/cmd/identity-service/main.go
@@ -10,6 +10,7 @@ import (
 	"os/signal"
 	"syscall"
 
+	authorizationv1 "github.com/agynio/identity/.gen/go/agynio/api/authorization/v1"
 	identityv1 "github.com/agynio/identity/.gen/go/agynio/api/identity/v1"
 	"github.com/agynio/identity/internal/config"
 	"github.com/agynio/identity/internal/db"
@@ -17,6 +18,7 @@ import (
 	"github.com/agynio/identity/internal/store"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 )
 
 func main() {
@@ -48,8 +50,14 @@ func run() error {
 		return fmt.Errorf("apply migrations: %w", err)
 	}
 
+	authConn, err := grpc.NewClient(cfg.AuthorizationAddress, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		return fmt.Errorf("connect to authorization: %w", err)
+	}
+	defer authConn.Close()
+
 	grpcServer := grpc.NewServer()
-	identityv1.RegisterIdentityServiceServer(grpcServer, server.New(store.New(pool)))
+	identityv1.RegisterIdentityServiceServer(grpcServer, server.New(store.New(pool), authorizationv1.NewAuthorizationServiceClient(authConn)))
 
 	lis, err := net.Listen("tcp", cfg.GRPCAddress)
 	if err != nil {

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -52,7 +52,7 @@ functions:
                     sleep 1; elapsed=$((elapsed + 1))
                     [ "$elapsed" -ge 120 ] && { echo "ERROR: sync timeout" >&2; exit 1; }
                   done
-                  buf generate buf.build/agynio/api --path agynio/api/identity/v1
+                  buf generate buf.build/agynio/api --path agynio/api/identity/v1 --path agynio/api/authorization/v1
                   exec go run ./cmd/identity-service
               volumeMounts:
                 - name: data
@@ -135,7 +135,7 @@ pipelines:
       exec_container \
         --label-selector "app.kubernetes.io/name=identity-e2e" \
         -n ${IDENTITY_NAMESPACE} \
-        -- bash -c 'cd /opt/app/data && buf generate buf.build/agynio/api --path agynio/api/identity/v1 && go test -v -count=1 -tags e2e ./test/e2e/'
+        -- bash -c 'cd /opt/app/data && buf generate buf.build/agynio/api --path agynio/api/identity/v1 --path agynio/api/authorization/v1 && go test -v -count=1 -tags e2e ./test/e2e/'
       EXIT_CODE=$?
       stop_dev e2e-runner
       purge_deployments e2e-runner

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,8 +6,9 @@ import (
 )
 
 type Config struct {
-	GRPCAddress string
-	DatabaseURL string
+	GRPCAddress          string
+	DatabaseURL          string
+	AuthorizationAddress string
 }
 
 func FromEnv() (Config, error) {
@@ -19,6 +20,10 @@ func FromEnv() (Config, error) {
 	cfg.DatabaseURL = os.Getenv("DATABASE_URL")
 	if cfg.DatabaseURL == "" {
 		return Config{}, fmt.Errorf("DATABASE_URL must be set")
+	}
+	cfg.AuthorizationAddress = os.Getenv("AUTHORIZATION_ADDRESS")
+	if cfg.AuthorizationAddress == "" {
+		cfg.AuthorizationAddress = "authorization:50051"
 	}
 	return cfg, nil
 }

--- a/internal/server/auth.go
+++ b/internal/server/auth.go
@@ -1,0 +1,46 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	authorizationv1 "github.com/agynio/identity/.gen/go/agynio/api/authorization/v1"
+	"github.com/google/uuid"
+	"google.golang.org/grpc/metadata"
+)
+
+const (
+	identityHeaderKey        = "x-identity-id"
+	identityObjectPrefix     = "identity:"
+	organizationObjectPrefix = "organization:"
+)
+
+func identityIDFromContext(ctx context.Context) (uuid.UUID, error) {
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return uuid.Nil, fmt.Errorf("metadata missing")
+	}
+	values := md.Get(identityHeaderKey)
+	if len(values) == 0 || strings.TrimSpace(values[0]) == "" {
+		return uuid.Nil, fmt.Errorf("%s not found in metadata", identityHeaderKey)
+	}
+	return uuid.Parse(strings.TrimSpace(values[0]))
+}
+
+func (s *Server) checkPermission(ctx context.Context, identityID uuid.UUID, relation string, organizationID uuid.UUID) (bool, error) {
+	if s.authorizationClient == nil {
+		return false, fmt.Errorf("authorization client not configured")
+	}
+	response, err := s.authorizationClient.Check(ctx, &authorizationv1.CheckRequest{
+		TupleKey: &authorizationv1.TupleKey{
+			User:     fmt.Sprintf("%s%s", identityObjectPrefix, identityID.String()),
+			Relation: relation,
+			Object:   fmt.Sprintf("%s%s", organizationObjectPrefix, organizationID.String()),
+		},
+	})
+	if err != nil {
+		return false, err
+	}
+	return response.GetAllowed(), nil
+}

--- a/internal/server/converter.go
+++ b/internal/server/converter.go
@@ -7,11 +7,10 @@ import (
 )
 
 const (
-	dbIdentityTypeUser    int16 = 1
-	dbIdentityTypeAgent   int16 = 2
-	dbIdentityTypeChannel int16 = 3
-	dbIdentityTypeRunner  int16 = 4
-	dbIdentityTypeApp     int16 = 5
+	dbIdentityTypeUser   int16 = 1
+	dbIdentityTypeAgent  int16 = 2
+	dbIdentityTypeRunner int16 = 4
+	dbIdentityTypeApp    int16 = 5
 )
 
 var identityTypeMappings = []struct {
@@ -20,7 +19,6 @@ var identityTypeMappings = []struct {
 }{
 	{proto: identityv1.IdentityType_IDENTITY_TYPE_USER, db: dbIdentityTypeUser},
 	{proto: identityv1.IdentityType_IDENTITY_TYPE_AGENT, db: dbIdentityTypeAgent},
-	{proto: identityv1.IdentityType_IDENTITY_TYPE_CHANNEL, db: dbIdentityTypeChannel},
 	{proto: identityv1.IdentityType_IDENTITY_TYPE_RUNNER, db: dbIdentityTypeRunner},
 	{proto: identityv1.IdentityType_IDENTITY_TYPE_APP, db: dbIdentityTypeApp},
 }

--- a/internal/server/converter_test.go
+++ b/internal/server/converter_test.go
@@ -15,7 +15,6 @@ func TestIdentityTypeRoundTrip(t *testing.T) {
 	}{
 		{name: "user", proto: identityv1.IdentityType_IDENTITY_TYPE_USER, db: 1},
 		{name: "agent", proto: identityv1.IdentityType_IDENTITY_TYPE_AGENT, db: 2},
-		{name: "channel", proto: identityv1.IdentityType_IDENTITY_TYPE_CHANNEL, db: 3},
 		{name: "runner", proto: identityv1.IdentityType_IDENTITY_TYPE_RUNNER, db: 4},
 		{name: "app", proto: identityv1.IdentityType_IDENTITY_TYPE_APP, db: 5},
 	}

--- a/internal/server/nicknames.go
+++ b/internal/server/nicknames.go
@@ -1,0 +1,283 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+
+	identityv1 "github.com/agynio/identity/.gen/go/agynio/api/identity/v1"
+	"github.com/google/uuid"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+const nicknameMaxLength = 32
+
+var nicknamePattern = regexp.MustCompile(`^[a-z0-9_-]+$`)
+
+func (s *Server) SetNickname(ctx context.Context, req *identityv1.SetNicknameRequest) (*identityv1.SetNicknameResponse, error) {
+	callerID, err := identityIDFromContext(ctx)
+	if err != nil {
+		return nil, status.Errorf(codes.Unauthenticated, "identity not available: %v", err)
+	}
+
+	organizationID, err := parseUUID(req.GetOrganizationId())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "organization_id: %v", err)
+	}
+	identityID, err := parseUUID(req.GetIdentityId())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "identity_id: %v", err)
+	}
+	nickname, err := normalizeNickname(req.GetNickname())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "nickname: %v", err)
+	}
+	installationID, err := parseOptionalUUID(req.InstallationId)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "installation_id: %v", err)
+	}
+
+	if err := s.authorizeNicknameWrite(ctx, callerID, organizationID, identityID); err != nil {
+		return nil, err
+	}
+
+	identityType, err := s.store.GetIdentityType(ctx, identityID)
+	if err != nil {
+		return nil, toStatusError(err)
+	}
+	protoType, err := identityTypeToProto(identityType)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "internal error: %v", err)
+	}
+	if err := validateInstallationID(protoType, installationID); err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "installation_id: %v", err)
+	}
+
+	if err := s.store.SetNickname(ctx, organizationID, identityID, installationID, nickname); err != nil {
+		return nil, toStatusError(err)
+	}
+
+	return &identityv1.SetNicknameResponse{}, nil
+}
+
+func (s *Server) RemoveNickname(ctx context.Context, req *identityv1.RemoveNicknameRequest) (*identityv1.RemoveNicknameResponse, error) {
+	callerID, err := identityIDFromContext(ctx)
+	if err != nil {
+		return nil, status.Errorf(codes.Unauthenticated, "identity not available: %v", err)
+	}
+
+	organizationID, err := parseUUID(req.GetOrganizationId())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "organization_id: %v", err)
+	}
+	identityID, err := parseUUID(req.GetIdentityId())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "identity_id: %v", err)
+	}
+	installationID, err := parseOptionalUUID(req.InstallationId)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "installation_id: %v", err)
+	}
+
+	if err := s.authorizeNicknameWrite(ctx, callerID, organizationID, identityID); err != nil {
+		return nil, err
+	}
+
+	identityType, err := s.store.GetIdentityType(ctx, identityID)
+	if err != nil {
+		return nil, toStatusError(err)
+	}
+	protoType, err := identityTypeToProto(identityType)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "internal error: %v", err)
+	}
+	if err := validateInstallationID(protoType, installationID); err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "installation_id: %v", err)
+	}
+
+	if err := s.store.RemoveNickname(ctx, organizationID, identityID, installationID); err != nil {
+		return nil, toStatusError(err)
+	}
+
+	return &identityv1.RemoveNicknameResponse{}, nil
+}
+
+func (s *Server) ResolveNickname(ctx context.Context, req *identityv1.ResolveNicknameRequest) (*identityv1.ResolveNicknameResponse, error) {
+	callerID, err := identityIDFromContext(ctx)
+	if err != nil {
+		return nil, status.Errorf(codes.Unauthenticated, "identity not available: %v", err)
+	}
+
+	organizationID, err := parseUUID(req.GetOrganizationId())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "organization_id: %v", err)
+	}
+	nickname, err := normalizeNickname(req.GetNickname())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "nickname: %v", err)
+	}
+
+	if err := s.authorizeNicknameRead(ctx, callerID, organizationID); err != nil {
+		return nil, err
+	}
+
+	resolution, err := s.store.ResolveNickname(ctx, organizationID, nickname)
+	if err != nil {
+		return nil, toStatusError(err)
+	}
+	protoType, err := identityTypeToProto(resolution.IdentityType)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "internal error: %v", err)
+	}
+
+	response := &identityv1.ResolveNicknameResponse{
+		IdentityId:   resolution.IdentityID.String(),
+		IdentityType: protoType,
+	}
+	if resolution.InstallationID != nil {
+		installationID := resolution.InstallationID.String()
+		response.InstallationId = &installationID
+	}
+	return response, nil
+}
+
+func (s *Server) BatchGetNicknames(ctx context.Context, req *identityv1.BatchGetNicknamesRequest) (*identityv1.BatchGetNicknamesResponse, error) {
+	callerID, err := identityIDFromContext(ctx)
+	if err != nil {
+		return nil, status.Errorf(codes.Unauthenticated, "identity not available: %v", err)
+	}
+
+	organizationID, err := parseUUID(req.GetOrganizationId())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "organization_id: %v", err)
+	}
+
+	allowed, err := s.checkPermission(ctx, callerID, "can_view_threads", organizationID)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "authorization check: %v", err)
+	}
+	if !allowed {
+		return nil, status.Error(codes.PermissionDenied, "missing permission to view thread nicknames")
+	}
+
+	identityIDs := req.GetIdentityIds()
+	if len(identityIDs) == 0 {
+		return &identityv1.BatchGetNicknamesResponse{Entries: nil}, nil
+	}
+
+	ids := make([]uuid.UUID, 0, len(identityIDs))
+	for i, identityID := range identityIDs {
+		id, err := parseUUID(identityID)
+		if err != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "identity_ids[%d]: %v", i, err)
+		}
+		ids = append(ids, id)
+	}
+
+	nicknames, err := s.store.BatchGetNicknames(ctx, organizationID, ids)
+	if err != nil {
+		return nil, toStatusError(err)
+	}
+
+	entries := make([]*identityv1.NicknameEntry, 0, len(nicknames))
+	for _, id := range ids {
+		nickname, ok := nicknames[id]
+		if !ok {
+			continue
+		}
+		entries = append(entries, &identityv1.NicknameEntry{IdentityId: id.String(), Nickname: nickname})
+	}
+
+	return &identityv1.BatchGetNicknamesResponse{Entries: entries}, nil
+}
+
+func normalizeNickname(value string) (string, error) {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return "", fmt.Errorf("must be provided")
+	}
+	if len(trimmed) > nicknameMaxLength {
+		return "", fmt.Errorf("must be %d characters or fewer", nicknameMaxLength)
+	}
+	if !nicknamePattern.MatchString(trimmed) {
+		return "", fmt.Errorf("must match %s", nicknamePattern.String())
+	}
+	return trimmed, nil
+}
+
+func parseOptionalUUID(value *string) (*uuid.UUID, error) {
+	if value == nil {
+		return nil, nil
+	}
+	trimmed := strings.TrimSpace(*value)
+	if trimmed == "" {
+		return nil, fmt.Errorf("must be provided")
+	}
+	parsed, err := uuid.Parse(trimmed)
+	if err != nil {
+		return nil, err
+	}
+	return &parsed, nil
+}
+
+func validateInstallationID(identityType identityv1.IdentityType, installationID *uuid.UUID) error {
+	if identityType == identityv1.IdentityType_IDENTITY_TYPE_APP {
+		if installationID == nil {
+			return fmt.Errorf("required for app identities")
+		}
+		return nil
+	}
+	if installationID != nil {
+		return fmt.Errorf("only valid for app identities")
+	}
+	return nil
+}
+
+func (s *Server) authorizeNicknameWrite(ctx context.Context, callerID uuid.UUID, organizationID uuid.UUID, identityID uuid.UUID) error {
+	if callerID == identityID {
+		allowed, err := s.checkPermission(ctx, callerID, "member", organizationID)
+		if err != nil {
+			return status.Errorf(codes.Internal, "authorization check: %v", err)
+		}
+		if !allowed {
+			return status.Error(codes.PermissionDenied, "missing permission to manage nickname")
+		}
+		return nil
+	}
+
+	allowed, err := s.checkPermission(ctx, callerID, "can_manage_members", organizationID)
+	if err != nil {
+		return status.Errorf(codes.Internal, "authorization check: %v", err)
+	}
+	if allowed {
+		return nil
+	}
+	allowed, err = s.checkPermission(ctx, callerID, "can_add_member", organizationID)
+	if err != nil {
+		return status.Errorf(codes.Internal, "authorization check: %v", err)
+	}
+	if !allowed {
+		return status.Error(codes.PermissionDenied, "missing permission to manage nickname")
+	}
+	return nil
+}
+
+func (s *Server) authorizeNicknameRead(ctx context.Context, callerID uuid.UUID, organizationID uuid.UUID) error {
+	allowed, err := s.checkPermission(ctx, callerID, "member", organizationID)
+	if err != nil {
+		return status.Errorf(codes.Internal, "authorization check: %v", err)
+	}
+	if allowed {
+		return nil
+	}
+	allowed, err = s.checkPermission(ctx, callerID, "can_view_threads", organizationID)
+	if err != nil {
+		return status.Errorf(codes.Internal, "authorization check: %v", err)
+	}
+	if !allowed {
+		return status.Error(codes.PermissionDenied, "missing permission to view nicknames")
+	}
+	return nil
+}

--- a/internal/server/nicknames_test.go
+++ b/internal/server/nicknames_test.go
@@ -1,0 +1,132 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	authorizationv1 "github.com/agynio/identity/.gen/go/agynio/api/authorization/v1"
+	identityv1 "github.com/agynio/identity/.gen/go/agynio/api/identity/v1"
+	"github.com/agynio/identity/internal/store"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+)
+
+type fakeAuthClient struct {
+	allowed     bool
+	lastRequest *authorizationv1.CheckRequest
+	err         error
+}
+
+func (f *fakeAuthClient) Check(_ context.Context, req *authorizationv1.CheckRequest, _ ...grpc.CallOption) (*authorizationv1.CheckResponse, error) {
+	f.lastRequest = req
+	if f.err != nil {
+		return nil, f.err
+	}
+	return &authorizationv1.CheckResponse{Allowed: f.allowed}, nil
+}
+
+type fakeStore struct {
+	batchNicknames     map[uuid.UUID]string
+	batchErr           error
+	lastOrganizationID uuid.UUID
+	lastIdentityIDs    []uuid.UUID
+}
+
+func (f *fakeStore) RegisterIdentity(context.Context, uuid.UUID, int16) error {
+	return nil
+}
+
+func (f *fakeStore) GetIdentityType(context.Context, uuid.UUID) (int16, error) {
+	return dbIdentityTypeUser, nil
+}
+
+func (f *fakeStore) BatchGetIdentityTypes(context.Context, []uuid.UUID) (map[uuid.UUID]int16, error) {
+	return map[uuid.UUID]int16{}, nil
+}
+
+func (f *fakeStore) SetNickname(context.Context, uuid.UUID, uuid.UUID, *uuid.UUID, string) error {
+	return nil
+}
+
+func (f *fakeStore) RemoveNickname(context.Context, uuid.UUID, uuid.UUID, *uuid.UUID) error {
+	return nil
+}
+
+func (f *fakeStore) ResolveNickname(context.Context, uuid.UUID, string) (store.NicknameResolution, error) {
+	return store.NicknameResolution{}, nil
+}
+
+func (f *fakeStore) BatchGetNicknames(_ context.Context, organizationID uuid.UUID, identityIDs []uuid.UUID) (map[uuid.UUID]string, error) {
+	f.lastOrganizationID = organizationID
+	f.lastIdentityIDs = identityIDs
+	if f.batchErr != nil {
+		return nil, f.batchErr
+	}
+	return f.batchNicknames, nil
+}
+
+func TestBatchGetNicknamesOmitsMissing(t *testing.T) {
+	organizationID := uuid.New()
+	callerID := uuid.New()
+	firstIdentity := uuid.New()
+	secondIdentity := uuid.New()
+
+	store := &fakeStore{batchNicknames: map[uuid.UUID]string{secondIdentity: "runner"}}
+	auth := &fakeAuthClient{allowed: true}
+	server := New(store, auth)
+
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs(identityHeaderKey, callerID.String()))
+	response, err := server.BatchGetNicknames(ctx, &identityv1.BatchGetNicknamesRequest{
+		OrganizationId: organizationID.String(),
+		IdentityIds:    []string{firstIdentity.String(), secondIdentity.String()},
+	})
+	require.NoError(t, err)
+	require.Len(t, response.Entries, 1)
+	require.Equal(t, secondIdentity.String(), response.Entries[0].GetIdentityId())
+	require.Equal(t, "runner", response.Entries[0].GetNickname())
+
+	require.NotNil(t, auth.lastRequest)
+	require.Equal(t, "can_view_threads", auth.lastRequest.GetTupleKey().GetRelation())
+	require.Equal(t, fmt.Sprintf("%s%s", identityObjectPrefix, callerID.String()), auth.lastRequest.GetTupleKey().GetUser())
+	require.Equal(t, fmt.Sprintf("%s%s", organizationObjectPrefix, organizationID.String()), auth.lastRequest.GetTupleKey().GetObject())
+}
+
+func TestBatchGetNicknamesMissingIdentityHeader(t *testing.T) {
+	server := New(&fakeStore{}, &fakeAuthClient{allowed: true})
+	_, err := server.BatchGetNicknames(context.Background(), &identityv1.BatchGetNicknamesRequest{OrganizationId: uuid.NewString()})
+	requireStatusCode(t, err, codes.Unauthenticated)
+}
+
+func TestBatchGetNicknamesPermissionDenied(t *testing.T) {
+	callerID := uuid.New()
+	server := New(&fakeStore{}, &fakeAuthClient{allowed: false})
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs(identityHeaderKey, callerID.String()))
+	_, err := server.BatchGetNicknames(ctx, &identityv1.BatchGetNicknamesRequest{
+		OrganizationId: uuid.NewString(),
+		IdentityIds:    []string{uuid.NewString()},
+	})
+	requireStatusCode(t, err, codes.PermissionDenied)
+}
+
+func TestBatchGetNicknamesInvalidIdentityID(t *testing.T) {
+	callerID := uuid.New()
+	server := New(&fakeStore{}, &fakeAuthClient{allowed: true})
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs(identityHeaderKey, callerID.String()))
+	_, err := server.BatchGetNicknames(ctx, &identityv1.BatchGetNicknamesRequest{
+		OrganizationId: uuid.NewString(),
+		IdentityIds:    []string{"bad"},
+	})
+	requireStatusCode(t, err, codes.InvalidArgument)
+}
+
+func requireStatusCode(t *testing.T, err error, code codes.Code) {
+	t.Helper()
+	statusErr, ok := status.FromError(err)
+	require.True(t, ok)
+	require.Equal(t, code, statusErr.Code())
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -4,20 +4,37 @@ import (
 	"context"
 	"errors"
 
+	authorizationv1 "github.com/agynio/identity/.gen/go/agynio/api/authorization/v1"
 	identityv1 "github.com/agynio/identity/.gen/go/agynio/api/identity/v1"
 	"github.com/agynio/identity/internal/store"
 	"github.com/google/uuid"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
 
-type Server struct {
-	identityv1.UnimplementedIdentityServiceServer
-	store *store.Store
+type identityStore interface {
+	RegisterIdentity(context.Context, uuid.UUID, int16) error
+	GetIdentityType(context.Context, uuid.UUID) (int16, error)
+	BatchGetIdentityTypes(context.Context, []uuid.UUID) (map[uuid.UUID]int16, error)
+	SetNickname(context.Context, uuid.UUID, uuid.UUID, *uuid.UUID, string) error
+	RemoveNickname(context.Context, uuid.UUID, uuid.UUID, *uuid.UUID) error
+	ResolveNickname(context.Context, uuid.UUID, string) (store.NicknameResolution, error)
+	BatchGetNicknames(context.Context, uuid.UUID, []uuid.UUID) (map[uuid.UUID]string, error)
 }
 
-func New(store *store.Store) *Server {
-	return &Server{store: store}
+type authorizationChecker interface {
+	Check(context.Context, *authorizationv1.CheckRequest, ...grpc.CallOption) (*authorizationv1.CheckResponse, error)
+}
+
+type Server struct {
+	identityv1.UnimplementedIdentityServiceServer
+	store               identityStore
+	authorizationClient authorizationChecker
+}
+
+func New(store identityStore, authorizationClient authorizationChecker) *Server {
+	return &Server{store: store, authorizationClient: authorizationClient}
 }
 
 func (s *Server) RegisterIdentity(ctx context.Context, req *identityv1.RegisterIdentityRequest) (*identityv1.RegisterIdentityResponse, error) {

--- a/internal/store/nicknames.go
+++ b/internal/store/nicknames.go
@@ -1,0 +1,122 @@
+package store
+
+import (
+	"context"
+	"errors"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+type NicknameResolution struct {
+	IdentityID     uuid.UUID
+	IdentityType   int16
+	InstallationID *uuid.UUID
+}
+
+func (s *Store) SetNickname(ctx context.Context, organizationID uuid.UUID, identityID uuid.UUID, installationID *uuid.UUID, nickname string) error {
+	if installationID == nil {
+		_, err := s.pool.Exec(ctx, `INSERT INTO org_nicknames (organization_id, identity_id, installation_id, nickname)
+VALUES ($1, $2, NULL, $3)
+ON CONFLICT ON CONSTRAINT org_nicknames_org_identity_key
+DO UPDATE SET nickname = EXCLUDED.nickname`, organizationID, identityID, nickname)
+		if err != nil {
+			return mapNicknameError(err)
+		}
+		return nil
+	}
+
+	_, err := s.pool.Exec(ctx, `INSERT INTO org_nicknames (organization_id, identity_id, installation_id, nickname)
+VALUES ($1, $2, $3, $4)
+ON CONFLICT ON CONSTRAINT org_nicknames_org_installation_key
+DO UPDATE SET nickname = EXCLUDED.nickname, identity_id = EXCLUDED.identity_id`, organizationID, identityID, *installationID, nickname)
+	if err != nil {
+		return mapNicknameError(err)
+	}
+	return nil
+}
+
+func (s *Store) RemoveNickname(ctx context.Context, organizationID uuid.UUID, identityID uuid.UUID, installationID *uuid.UUID) error {
+	var tag pgconn.CommandTag
+	var err error
+	if installationID == nil {
+		tag, err = s.pool.Exec(ctx, `DELETE FROM org_nicknames WHERE organization_id = $1 AND identity_id = $2 AND installation_id IS NULL`, organizationID, identityID)
+	} else {
+		tag, err = s.pool.Exec(ctx, `DELETE FROM org_nicknames WHERE organization_id = $1 AND identity_id = $2 AND installation_id = $3`, organizationID, identityID, *installationID)
+	}
+	if err != nil {
+		return err
+	}
+	if tag.RowsAffected() == 0 {
+		return NotFound("nickname")
+	}
+	return nil
+}
+
+func (s *Store) ResolveNickname(ctx context.Context, organizationID uuid.UUID, nickname string) (NicknameResolution, error) {
+	var resolution NicknameResolution
+	var installationID pgtype.UUID
+	if err := s.pool.QueryRow(ctx, `SELECT n.identity_id, n.installation_id, i.identity_type
+FROM org_nicknames n
+JOIN identities i ON i.identity_id = n.identity_id
+WHERE n.organization_id = $1 AND n.nickname = $2`, organizationID, nickname).Scan(&resolution.IdentityID, &installationID, &resolution.IdentityType); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return NicknameResolution{}, NotFound("nickname")
+		}
+		return NicknameResolution{}, err
+	}
+	if installationID.Valid {
+		parsed := uuid.UUID(installationID.Bytes)
+		resolution.InstallationID = &parsed
+	}
+	return resolution, nil
+}
+
+func (s *Store) BatchGetNicknames(ctx context.Context, organizationID uuid.UUID, identityIDs []uuid.UUID) (map[uuid.UUID]string, error) {
+	if len(identityIDs) == 0 {
+		return map[uuid.UUID]string{}, nil
+	}
+
+	array := make([]pgtype.UUID, len(identityIDs))
+	for i, id := range identityIDs {
+		array[i] = pgtype.UUID{Bytes: id, Valid: true}
+	}
+
+	rows, err := s.pool.Query(ctx, `SELECT identity_id, nickname
+FROM org_nicknames
+WHERE organization_id = $1 AND identity_id = ANY($2)
+ORDER BY identity_id`, organizationID, array)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	nicknames := make(map[uuid.UUID]string, len(identityIDs))
+	for rows.Next() {
+		var identityID uuid.UUID
+		var nickname string
+		if err := rows.Scan(&identityID, &nickname); err != nil {
+			return nil, err
+		}
+		nicknames[identityID] = nickname
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return nicknames, nil
+}
+
+func mapNicknameError(err error) error {
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) {
+		switch pgErr.Code {
+		case "23505":
+			return AlreadyExists("nickname")
+		case "23503":
+			return NotFound("identity")
+		}
+	}
+	return err
+}

--- a/internal/store/nicknames.go
+++ b/internal/store/nicknames.go
@@ -20,7 +20,8 @@ func (s *Store) SetNickname(ctx context.Context, organizationID uuid.UUID, ident
 	if installationID == nil {
 		_, err := s.pool.Exec(ctx, `INSERT INTO org_nicknames (organization_id, identity_id, installation_id, nickname)
 VALUES ($1, $2, NULL, $3)
-ON CONFLICT ON CONSTRAINT org_nicknames_org_identity_key
+ON CONFLICT (organization_id, identity_id)
+WHERE installation_id IS NULL
 DO UPDATE SET nickname = EXCLUDED.nickname`, organizationID, identityID, nickname)
 		if err != nil {
 			return mapNicknameError(err)
@@ -30,7 +31,8 @@ DO UPDATE SET nickname = EXCLUDED.nickname`, organizationID, identityID, nicknam
 
 	_, err := s.pool.Exec(ctx, `INSERT INTO org_nicknames (organization_id, identity_id, installation_id, nickname)
 VALUES ($1, $2, $3, $4)
-ON CONFLICT ON CONSTRAINT org_nicknames_org_installation_key
+ON CONFLICT (organization_id, installation_id)
+WHERE installation_id IS NOT NULL
 DO UPDATE SET nickname = EXCLUDED.nickname, identity_id = EXCLUDED.identity_id`, organizationID, identityID, *installationID, nickname)
 	if err != nil {
 		return mapNicknameError(err)

--- a/migrations/0002_org_nicknames.sql
+++ b/migrations/0002_org_nicknames.sql
@@ -1,0 +1,18 @@
+CREATE TABLE org_nicknames (
+    organization_id UUID        NOT NULL,
+    identity_id     UUID        NOT NULL REFERENCES identities(identity_id) ON DELETE CASCADE,
+    installation_id UUID,
+    nickname        TEXT        NOT NULL,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX org_nicknames_org_nickname_key
+    ON org_nicknames (organization_id, nickname);
+
+CREATE UNIQUE INDEX org_nicknames_org_identity_key
+    ON org_nicknames (organization_id, identity_id)
+    WHERE installation_id IS NULL;
+
+CREATE UNIQUE INDEX org_nicknames_org_installation_key
+    ON org_nicknames (organization_id, installation_id)
+    WHERE installation_id IS NOT NULL;


### PR DESCRIPTION
## Summary
- add org nickname storage/migrations and nickname RPC handlers, including BatchGetNicknames authorization checks
- wire Authorization client config and codegen paths for identity + authorization protos
- update identity type mappings/tests and add BatchGetNicknames unit coverage

## Testing
- GOTOOLCHAIN=local go test ./...
- GOTOOLCHAIN=local go vet ./...

## Issue
- #5