### PR TITLE
feat(identity): support agent instance handles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
           version: 1.66.0
 
       - name: Generate protobuf bindings
-        run: buf generate https://github.com/agynio/api.git#commit=7326d1b87be7700a4bc175e5ce8150de3f46484c --path proto/agynio/api/identity/v1 --path proto/agynio/api/authorization/v1
+        run: buf generate https://github.com/agynio/api.git#branch=noa/issue-161-identity-foundation --path proto/agynio/api/identity/v1 --path proto/agynio/api/authorization/v1
 
       - name: Run tests
         run: go test ./...

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -39,7 +39,7 @@ jobs:
           version: 1.66.0
 
       - name: Prepare generated sources
-        run: buf generate buf.build/agynio/api --path agynio/api/identity/v1 --path agynio/api/authorization/v1
+        run: buf generate https://github.com/agynio/api.git#branch=noa/issue-161-identity-foundation --path proto/agynio/api/identity/v1 --path proto/agynio/api/authorization/v1
 
       - name: Build source binary for DevSpace
         run: |

--- a/internal/server/converter.go
+++ b/internal/server/converter.go
@@ -7,10 +7,11 @@ import (
 )
 
 const (
-	dbIdentityTypeUser   int16 = 1
-	dbIdentityTypeAgent  int16 = 2
-	dbIdentityTypeRunner int16 = 4
-	dbIdentityTypeApp    int16 = 5
+	dbIdentityTypeUser          int16 = 1
+	dbIdentityTypeAgent         int16 = 2
+	dbIdentityTypeRunner        int16 = 4
+	dbIdentityTypeApp           int16 = 5
+	dbIdentityTypeAgentInstance int16 = 6
 )
 
 var identityTypeMappings = []struct {
@@ -21,6 +22,7 @@ var identityTypeMappings = []struct {
 	{proto: identityv1.IdentityType_IDENTITY_TYPE_AGENT, db: dbIdentityTypeAgent},
 	{proto: identityv1.IdentityType_IDENTITY_TYPE_RUNNER, db: dbIdentityTypeRunner},
 	{proto: identityv1.IdentityType_IDENTITY_TYPE_APP, db: dbIdentityTypeApp},
+	{proto: identityv1.IdentityType_IDENTITY_TYPE_AGENT_INSTANCE, db: dbIdentityTypeAgentInstance},
 }
 
 func identityTypeFromProto(value identityv1.IdentityType) (int16, error) {

--- a/internal/server/converter_test.go
+++ b/internal/server/converter_test.go
@@ -17,6 +17,7 @@ func TestIdentityTypeRoundTrip(t *testing.T) {
 		{name: "agent", proto: identityv1.IdentityType_IDENTITY_TYPE_AGENT, db: 2},
 		{name: "runner", proto: identityv1.IdentityType_IDENTITY_TYPE_RUNNER, db: 4},
 		{name: "app", proto: identityv1.IdentityType_IDENTITY_TYPE_APP, db: 5},
+		{name: "agent_instance", proto: identityv1.IdentityType_IDENTITY_TYPE_AGENT_INSTANCE, db: 6},
 	}
 
 	for _, testCase := range testCases {

--- a/internal/server/nicknames.go
+++ b/internal/server/nicknames.go
@@ -30,9 +30,13 @@ func (s *Server) SetNickname(ctx context.Context, req *identityv1.SetNicknameReq
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "identity_id: %v", err)
 	}
-	nickname, err := normalizeNickname(req.GetNickname())
+	nickname, err := normalizeNicknameStem(req.GetNickname())
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "nickname: %v", err)
+	}
+	instanceSuffix, err := parseOptionalHandleSegment(req.InstanceSuffix)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "instance_suffix: %v", err)
 	}
 	installationID, err := parseOptionalUUID(req.InstallationId)
 	if err != nil {
@@ -54,8 +58,11 @@ func (s *Server) SetNickname(ctx context.Context, req *identityv1.SetNicknameReq
 	if err := validateInstallationID(protoType, installationID); err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "installation_id: %v", err)
 	}
+	if err := validateInstanceSuffix(protoType, instanceSuffix); err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "instance_suffix: %v", err)
+	}
 
-	if err := s.store.SetNickname(ctx, organizationID, identityID, installationID, nickname); err != nil {
+	if err := s.store.SetNickname(ctx, organizationID, identityID, installationID, nickname, instanceSuffix); err != nil {
 		return nil, toStatusError(err)
 	}
 
@@ -114,7 +121,7 @@ func (s *Server) ResolveNickname(ctx context.Context, req *identityv1.ResolveNic
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "organization_id: %v", err)
 	}
-	nickname, err := normalizeNickname(req.GetNickname())
+	nickname, instanceSuffix, err := parseNicknameHandle(req.GetNickname(), req.InstanceSuffix)
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "nickname: %v", err)
 	}
@@ -123,7 +130,7 @@ func (s *Server) ResolveNickname(ctx context.Context, req *identityv1.ResolveNic
 		return nil, err
 	}
 
-	resolution, err := s.store.ResolveNickname(ctx, organizationID, nickname)
+	resolution, err := s.store.ResolveNickname(ctx, organizationID, nickname, instanceSuffix)
 	if err != nil {
 		return nil, toStatusError(err)
 	}
@@ -139,6 +146,9 @@ func (s *Server) ResolveNickname(ctx context.Context, req *identityv1.ResolveNic
 	if resolution.InstallationID != nil {
 		installationID := resolution.InstallationID.String()
 		response.InstallationId = &installationID
+	}
+	if resolution.InstanceSuffix != nil {
+		response.InstanceSuffix = resolution.InstanceSuffix
 	}
 	return response, nil
 }
@@ -187,13 +197,25 @@ func (s *Server) BatchGetNicknames(ctx context.Context, req *identityv1.BatchGet
 		if !ok {
 			continue
 		}
-		entries = append(entries, &identityv1.NicknameEntry{IdentityId: id.String(), Nickname: nickname})
+		entries = append(entries, &identityv1.NicknameEntry{
+			IdentityId:      id.String(),
+			Nickname:        nickname.Nickname,
+			InstanceSuffix: nickname.InstanceSuffix,
+		})
 	}
 
 	return &identityv1.BatchGetNicknamesResponse{Entries: entries}, nil
 }
 
-func normalizeNickname(value string) (string, error) {
+func normalizeNicknameStem(value string) (string, error) {
+	trimmed := strings.TrimPrefix(strings.TrimSpace(value), "@")
+	if strings.Contains(trimmed, "#") {
+		return "", fmt.Errorf("must not include instance suffix")
+	}
+	return normalizeHandleSegment(trimmed)
+}
+
+func normalizeHandleSegment(value string) (string, error) {
 	trimmed := strings.TrimSpace(value)
 	if trimmed == "" {
 		return "", fmt.Errorf("must be provided")
@@ -205,6 +227,54 @@ func normalizeNickname(value string) (string, error) {
 		return "", fmt.Errorf("must match %s", nicknamePattern.String())
 	}
 	return trimmed, nil
+}
+
+func parseNicknameHandle(value string, explicitSuffix *string) (string, *string, error) {
+	trimmed := strings.TrimPrefix(strings.TrimSpace(value), "@")
+	if trimmed == "" {
+		return "", nil, fmt.Errorf("must be provided")
+	}
+	if explicitSuffix != nil && strings.Contains(trimmed, "#") {
+		return "", nil, fmt.Errorf("must not include # when instance_suffix is set")
+	}
+	if explicitSuffix != nil {
+		nickname, err := normalizeNicknameStem(trimmed)
+		if err != nil {
+			return "", nil, err
+		}
+		instanceSuffix, err := parseOptionalHandleSegment(explicitSuffix)
+		if err != nil {
+			return "", nil, fmt.Errorf("instance_suffix: %w", err)
+		}
+		return nickname, instanceSuffix, nil
+	}
+	parts := strings.Split(trimmed, "#")
+	if len(parts) > 2 {
+		return "", nil, fmt.Errorf("must contain at most one #")
+	}
+	nickname, err := normalizeHandleSegment(parts[0])
+	if err != nil {
+		return "", nil, err
+	}
+	if len(parts) == 1 {
+		return nickname, nil, nil
+	}
+	instanceSuffix, err := normalizeHandleSegment(parts[1])
+	if err != nil {
+		return "", nil, fmt.Errorf("instance_suffix: %w", err)
+	}
+	return nickname, &instanceSuffix, nil
+}
+
+func parseOptionalHandleSegment(value *string) (*string, error) {
+	if value == nil {
+		return nil, nil
+	}
+	normalized, err := normalizeHandleSegment(*value)
+	if err != nil {
+		return nil, err
+	}
+	return &normalized, nil
 }
 
 func parseOptionalUUID(value *string) (*uuid.UUID, error) {
@@ -231,6 +301,19 @@ func validateInstallationID(identityType identityv1.IdentityType, installationID
 	}
 	if installationID != nil {
 		return fmt.Errorf("only valid for app identities")
+	}
+	return nil
+}
+
+func validateInstanceSuffix(identityType identityv1.IdentityType, instanceSuffix *string) error {
+	if identityType == identityv1.IdentityType_IDENTITY_TYPE_AGENT_INSTANCE {
+		if instanceSuffix == nil {
+			return fmt.Errorf("required for agent_instance identities")
+		}
+		return nil
+	}
+	if instanceSuffix != nil {
+		return fmt.Errorf("only valid for agent_instance identities")
 	}
 	return nil
 }

--- a/internal/server/nicknames_test.go
+++ b/internal/server/nicknames_test.go
@@ -31,17 +31,26 @@ func (f *fakeAuthClient) Check(_ context.Context, req *authorizationv1.CheckRequ
 }
 
 type fakeStore struct {
-	batchNicknames     map[uuid.UUID]string
+	batchNicknames     map[uuid.UUID]store.NicknameEntry
 	batchErr           error
 	lastOrganizationID uuid.UUID
 	lastIdentityIDs    []uuid.UUID
+	identityTypes      map[uuid.UUID]int16
+	lastNickname       string
+	lastInstanceSuffix *string
+	resolution         store.NicknameResolution
 }
 
 func (f *fakeStore) RegisterIdentity(context.Context, uuid.UUID, int16) error {
 	return nil
 }
 
-func (f *fakeStore) GetIdentityType(context.Context, uuid.UUID) (int16, error) {
+func (f *fakeStore) GetIdentityType(_ context.Context, identityID uuid.UUID) (int16, error) {
+	if f.identityTypes != nil {
+		if identityType, ok := f.identityTypes[identityID]; ok {
+			return identityType, nil
+		}
+	}
 	return dbIdentityTypeUser, nil
 }
 
@@ -49,7 +58,9 @@ func (f *fakeStore) BatchGetIdentityTypes(context.Context, []uuid.UUID) (map[uui
 	return map[uuid.UUID]int16{}, nil
 }
 
-func (f *fakeStore) SetNickname(context.Context, uuid.UUID, uuid.UUID, *uuid.UUID, string) error {
+func (f *fakeStore) SetNickname(_ context.Context, _ uuid.UUID, _ uuid.UUID, _ *uuid.UUID, nickname string, instanceSuffix *string) error {
+	f.lastNickname = nickname
+	f.lastInstanceSuffix = instanceSuffix
 	return nil
 }
 
@@ -57,11 +68,13 @@ func (f *fakeStore) RemoveNickname(context.Context, uuid.UUID, uuid.UUID, *uuid.
 	return nil
 }
 
-func (f *fakeStore) ResolveNickname(context.Context, uuid.UUID, string) (store.NicknameResolution, error) {
-	return store.NicknameResolution{}, nil
+func (f *fakeStore) ResolveNickname(_ context.Context, _ uuid.UUID, nickname string, instanceSuffix *string) (store.NicknameResolution, error) {
+	f.lastNickname = nickname
+	f.lastInstanceSuffix = instanceSuffix
+	return f.resolution, nil
 }
 
-func (f *fakeStore) BatchGetNicknames(_ context.Context, organizationID uuid.UUID, identityIDs []uuid.UUID) (map[uuid.UUID]string, error) {
+func (f *fakeStore) BatchGetNicknames(_ context.Context, organizationID uuid.UUID, identityIDs []uuid.UUID) (map[uuid.UUID]store.NicknameEntry, error) {
 	f.lastOrganizationID = organizationID
 	f.lastIdentityIDs = identityIDs
 	if f.batchErr != nil {
@@ -76,7 +89,7 @@ func TestBatchGetNicknamesOmitsMissing(t *testing.T) {
 	firstIdentity := uuid.New()
 	secondIdentity := uuid.New()
 
-	store := &fakeStore{batchNicknames: map[uuid.UUID]string{secondIdentity: "runner"}}
+	store := &fakeStore{batchNicknames: map[uuid.UUID]store.NicknameEntry{secondIdentity: {Nickname: "runner"}}}
 	auth := &fakeAuthClient{allowed: true}
 	server := New(store, auth)
 
@@ -129,4 +142,119 @@ func requireStatusCode(t *testing.T, err error, code codes.Code) {
 	statusErr, ok := status.FromError(err)
 	require.True(t, ok)
 	require.Equal(t, code, statusErr.Code())
+}
+
+func TestSetNicknameAcceptsAgentInstanceSuffix(t *testing.T) {
+	organizationID := uuid.New()
+	callerID := uuid.New()
+	identityID := uuid.New()
+	instanceSuffix := "planning-run-1"
+	store := &fakeStore{identityTypes: map[uuid.UUID]int16{identityID: dbIdentityTypeAgentInstance}}
+	server := New(store, &fakeAuthClient{allowed: true})
+
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs(identityHeaderKey, callerID.String()))
+	_, err := server.SetNickname(ctx, &identityv1.SetNicknameRequest{
+		OrganizationId: organizationID.String(),
+		IdentityId:     identityID.String(),
+		Nickname:       "@bob",
+		InstanceSuffix: &instanceSuffix,
+	})
+	require.NoError(t, err)
+	require.Equal(t, "bob", store.lastNickname)
+	require.NotNil(t, store.lastInstanceSuffix)
+	require.Equal(t, instanceSuffix, *store.lastInstanceSuffix)
+}
+
+func TestSetNicknameRequiresSuffixForAgentInstance(t *testing.T) {
+	organizationID := uuid.New()
+	callerID := uuid.New()
+	identityID := uuid.New()
+	store := &fakeStore{identityTypes: map[uuid.UUID]int16{identityID: dbIdentityTypeAgentInstance}}
+	server := New(store, &fakeAuthClient{allowed: true})
+
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs(identityHeaderKey, callerID.String()))
+	_, err := server.SetNickname(ctx, &identityv1.SetNicknameRequest{
+		OrganizationId: organizationID.String(),
+		IdentityId:     identityID.String(),
+		Nickname:       "bob",
+	})
+	requireStatusCode(t, err, codes.InvalidArgument)
+}
+
+func TestSetNicknameRejectsSuffixForNonInstance(t *testing.T) {
+	organizationID := uuid.New()
+	callerID := uuid.New()
+	identityID := uuid.New()
+	instanceSuffix := "7a2f"
+	store := &fakeStore{identityTypes: map[uuid.UUID]int16{identityID: dbIdentityTypeAgent}}
+	server := New(store, &fakeAuthClient{allowed: true})
+
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs(identityHeaderKey, callerID.String()))
+	_, err := server.SetNickname(ctx, &identityv1.SetNicknameRequest{
+		OrganizationId: organizationID.String(),
+		IdentityId:     identityID.String(),
+		Nickname:       "bob",
+		InstanceSuffix: &instanceSuffix,
+	})
+	requireStatusCode(t, err, codes.InvalidArgument)
+}
+
+func TestResolveNicknameParsesInstanceHandle(t *testing.T) {
+	organizationID := uuid.New()
+	callerID := uuid.New()
+	identityID := uuid.New()
+	instanceSuffix := "7a2f"
+	store := &fakeStore{resolution: store.NicknameResolution{
+		IdentityID:     identityID,
+		IdentityType:   dbIdentityTypeAgentInstance,
+		InstanceSuffix: &instanceSuffix,
+	}}
+	server := New(store, &fakeAuthClient{allowed: true})
+
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs(identityHeaderKey, callerID.String()))
+	response, err := server.ResolveNickname(ctx, &identityv1.ResolveNicknameRequest{
+		OrganizationId: organizationID.String(),
+		Nickname:       "@bob#7a2f",
+	})
+	require.NoError(t, err)
+	require.Equal(t, "bob", store.lastNickname)
+	require.NotNil(t, store.lastInstanceSuffix)
+	require.Equal(t, instanceSuffix, *store.lastInstanceSuffix)
+	require.Equal(t, identityID.String(), response.GetIdentityId())
+	require.Equal(t, identityv1.IdentityType_IDENTITY_TYPE_AGENT_INSTANCE, response.GetIdentityType())
+	require.Equal(t, instanceSuffix, response.GetInstanceSuffix())
+}
+
+func TestResolveNicknameRejectsDuplicateSuffixInputs(t *testing.T) {
+	organizationID := uuid.New()
+	callerID := uuid.New()
+	instanceSuffix := "7a2f"
+	server := New(&fakeStore{}, &fakeAuthClient{allowed: true})
+
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs(identityHeaderKey, callerID.String()))
+	_, err := server.ResolveNickname(ctx, &identityv1.ResolveNicknameRequest{
+		OrganizationId: organizationID.String(),
+		Nickname:       "bob#7a2f",
+		InstanceSuffix: &instanceSuffix,
+	})
+	requireStatusCode(t, err, codes.InvalidArgument)
+}
+
+func TestBatchGetNicknamesReturnsInstanceSuffix(t *testing.T) {
+	organizationID := uuid.New()
+	callerID := uuid.New()
+	identityID := uuid.New()
+	instanceSuffix := "7a2f"
+	store := &fakeStore{batchNicknames: map[uuid.UUID]store.NicknameEntry{identityID: {Nickname: "bob", InstanceSuffix: &instanceSuffix}}}
+	server := New(store, &fakeAuthClient{allowed: true})
+
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs(identityHeaderKey, callerID.String()))
+	response, err := server.BatchGetNicknames(ctx, &identityv1.BatchGetNicknamesRequest{
+		OrganizationId: organizationID.String(),
+		IdentityIds:    []string{identityID.String()},
+	})
+	require.NoError(t, err)
+	require.Len(t, response.Entries, 1)
+	require.Equal(t, "bob", response.Entries[0].GetNickname())
+	require.Equal(t, instanceSuffix, response.Entries[0].GetInstanceSuffix())
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -17,10 +17,10 @@ type identityStore interface {
 	RegisterIdentity(context.Context, uuid.UUID, int16) error
 	GetIdentityType(context.Context, uuid.UUID) (int16, error)
 	BatchGetIdentityTypes(context.Context, []uuid.UUID) (map[uuid.UUID]int16, error)
-	SetNickname(context.Context, uuid.UUID, uuid.UUID, *uuid.UUID, string) error
+	SetNickname(context.Context, uuid.UUID, uuid.UUID, *uuid.UUID, string, *string) error
 	RemoveNickname(context.Context, uuid.UUID, uuid.UUID, *uuid.UUID) error
-	ResolveNickname(context.Context, uuid.UUID, string) (store.NicknameResolution, error)
-	BatchGetNicknames(context.Context, uuid.UUID, []uuid.UUID) (map[uuid.UUID]string, error)
+	ResolveNickname(context.Context, uuid.UUID, string, *string) (store.NicknameResolution, error)
+	BatchGetNicknames(context.Context, uuid.UUID, []uuid.UUID) (map[uuid.UUID]store.NicknameEntry, error)
 }
 
 type authorizationChecker interface {

--- a/internal/store/nicknames.go
+++ b/internal/store/nicknames.go
@@ -14,15 +14,21 @@ type NicknameResolution struct {
 	IdentityID     uuid.UUID
 	IdentityType   int16
 	InstallationID *uuid.UUID
+	InstanceSuffix *string
 }
 
-func (s *Store) SetNickname(ctx context.Context, organizationID uuid.UUID, identityID uuid.UUID, installationID *uuid.UUID, nickname string) error {
+type NicknameEntry struct {
+	Nickname       string
+	InstanceSuffix *string
+}
+
+func (s *Store) SetNickname(ctx context.Context, organizationID uuid.UUID, identityID uuid.UUID, installationID *uuid.UUID, nickname string, instanceSuffix *string) error {
 	if installationID == nil {
-		_, err := s.pool.Exec(ctx, `INSERT INTO org_nicknames (organization_id, identity_id, installation_id, nickname)
-VALUES ($1, $2, NULL, $3)
+		_, err := s.pool.Exec(ctx, `INSERT INTO org_nicknames (organization_id, identity_id, installation_id, nickname, instance_suffix)
+VALUES ($1, $2, NULL, $3, $4)
 ON CONFLICT (organization_id, identity_id)
 WHERE installation_id IS NULL
-DO UPDATE SET nickname = EXCLUDED.nickname`, organizationID, identityID, nickname)
+DO UPDATE SET nickname = EXCLUDED.nickname, instance_suffix = EXCLUDED.instance_suffix`, organizationID, identityID, nickname, instanceSuffix)
 		if err != nil {
 			return mapNicknameError(err)
 		}
@@ -57,13 +63,14 @@ func (s *Store) RemoveNickname(ctx context.Context, organizationID uuid.UUID, id
 	return nil
 }
 
-func (s *Store) ResolveNickname(ctx context.Context, organizationID uuid.UUID, nickname string) (NicknameResolution, error) {
+func (s *Store) ResolveNickname(ctx context.Context, organizationID uuid.UUID, nickname string, instanceSuffix *string) (NicknameResolution, error) {
 	var resolution NicknameResolution
 	var installationID pgtype.UUID
-	if err := s.pool.QueryRow(ctx, `SELECT n.identity_id, n.installation_id, i.identity_type
+	var storedInstanceSuffix pgtype.Text
+	if err := s.pool.QueryRow(ctx, `SELECT n.identity_id, n.installation_id, n.instance_suffix, i.identity_type
 FROM org_nicknames n
 JOIN identities i ON i.identity_id = n.identity_id
-WHERE n.organization_id = $1 AND n.nickname = $2`, organizationID, nickname).Scan(&resolution.IdentityID, &installationID, &resolution.IdentityType); err != nil {
+WHERE n.organization_id = $1 AND n.nickname = $2 AND COALESCE(n.instance_suffix, '') = COALESCE($3, '')`, organizationID, nickname, instanceSuffix).Scan(&resolution.IdentityID, &installationID, &storedInstanceSuffix, &resolution.IdentityType); err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return NicknameResolution{}, NotFound("nickname")
 		}
@@ -73,12 +80,15 @@ WHERE n.organization_id = $1 AND n.nickname = $2`, organizationID, nickname).Sca
 		parsed := uuid.UUID(installationID.Bytes)
 		resolution.InstallationID = &parsed
 	}
+	if storedInstanceSuffix.Valid {
+		resolution.InstanceSuffix = &storedInstanceSuffix.String
+	}
 	return resolution, nil
 }
 
-func (s *Store) BatchGetNicknames(ctx context.Context, organizationID uuid.UUID, identityIDs []uuid.UUID) (map[uuid.UUID]string, error) {
+func (s *Store) BatchGetNicknames(ctx context.Context, organizationID uuid.UUID, identityIDs []uuid.UUID) (map[uuid.UUID]NicknameEntry, error) {
 	if len(identityIDs) == 0 {
-		return map[uuid.UUID]string{}, nil
+		return map[uuid.UUID]NicknameEntry{}, nil
 	}
 
 	array := make([]pgtype.UUID, len(identityIDs))
@@ -86,7 +96,7 @@ func (s *Store) BatchGetNicknames(ctx context.Context, organizationID uuid.UUID,
 		array[i] = pgtype.UUID{Bytes: id, Valid: true}
 	}
 
-	rows, err := s.pool.Query(ctx, `SELECT identity_id, nickname
+	rows, err := s.pool.Query(ctx, `SELECT identity_id, nickname, instance_suffix
 FROM org_nicknames
 WHERE organization_id = $1 AND identity_id = ANY($2)
 ORDER BY identity_id`, organizationID, array)
@@ -95,14 +105,19 @@ ORDER BY identity_id`, organizationID, array)
 	}
 	defer rows.Close()
 
-	nicknames := make(map[uuid.UUID]string, len(identityIDs))
+	nicknames := make(map[uuid.UUID]NicknameEntry, len(identityIDs))
 	for rows.Next() {
 		var identityID uuid.UUID
 		var nickname string
-		if err := rows.Scan(&identityID, &nickname); err != nil {
+		var instanceSuffix pgtype.Text
+		if err := rows.Scan(&identityID, &nickname, &instanceSuffix); err != nil {
 			return nil, err
 		}
-		nicknames[identityID] = nickname
+		entry := NicknameEntry{Nickname: nickname}
+		if instanceSuffix.Valid {
+			entry.InstanceSuffix = &instanceSuffix.String
+		}
+		nicknames[identityID] = entry
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err

--- a/migrations/0004_agent_instance_nicknames.sql
+++ b/migrations/0004_agent_instance_nicknames.sql
@@ -1,0 +1,8 @@
+ALTER TABLE org_nicknames
+    ADD COLUMN instance_suffix TEXT;
+
+DROP INDEX IF EXISTS org_nicknames_org_nickname_key;
+
+CREATE UNIQUE INDEX org_nicknames_org_nickname_suffix_key
+    ON org_nicknames (organization_id, nickname, COALESCE(instance_suffix, ''));
+

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -46,11 +46,23 @@ func TestIdentityServiceE2E(t *testing.T) {
 		getResp, err := client.GetIdentityType(ctx, &identityv1.GetIdentityTypeRequest{IdentityId: identityID})
 		require.NoError(t, err)
 		require.Equal(t, identityv1.IdentityType_IDENTITY_TYPE_USER, getResp.IdentityType)
+
+		agentInstanceID := uuid.NewString()
+		_, err = client.RegisterIdentity(ctx, &identityv1.RegisterIdentityRequest{
+			IdentityId:   agentInstanceID,
+			IdentityType: identityv1.IdentityType_IDENTITY_TYPE_AGENT_INSTANCE,
+		})
+		require.NoError(t, err)
+
+		agentInstanceResp, err := client.GetIdentityType(ctx, &identityv1.GetIdentityTypeRequest{IdentityId: agentInstanceID})
+		require.NoError(t, err)
+		require.Equal(t, identityv1.IdentityType_IDENTITY_TYPE_AGENT_INSTANCE, agentInstanceResp.IdentityType)
 	})
 
 	t.Run("BatchGetIdentityTypes", func(t *testing.T) {
 		firstID := uuid.NewString()
 		secondID := uuid.NewString()
+		thirdID := uuid.NewString()
 		_, err := client.RegisterIdentity(ctx, &identityv1.RegisterIdentityRequest{
 			IdentityId:   firstID,
 			IdentityType: identityv1.IdentityType_IDENTITY_TYPE_USER,
@@ -61,14 +73,20 @@ func TestIdentityServiceE2E(t *testing.T) {
 			IdentityType: identityv1.IdentityType_IDENTITY_TYPE_AGENT,
 		})
 		require.NoError(t, err)
-
-		batchResp, err := client.BatchGetIdentityTypes(ctx, &identityv1.BatchGetIdentityTypesRequest{
-			IdentityIds: []string{secondID, uuid.NewString(), firstID},
+		_, err = client.RegisterIdentity(ctx, &identityv1.RegisterIdentityRequest{
+			IdentityId:   thirdID,
+			IdentityType: identityv1.IdentityType_IDENTITY_TYPE_AGENT_INSTANCE,
 		})
 		require.NoError(t, err)
-		require.Len(t, batchResp.Entries, 2)
+
+		batchResp, err := client.BatchGetIdentityTypes(ctx, &identityv1.BatchGetIdentityTypesRequest{
+			IdentityIds: []string{secondID, uuid.NewString(), thirdID, firstID},
+		})
+		require.NoError(t, err)
+		require.Len(t, batchResp.Entries, 3)
 		require.True(t, hasIdentityType(batchResp.Entries, firstID, identityv1.IdentityType_IDENTITY_TYPE_USER))
 		require.True(t, hasIdentityType(batchResp.Entries, secondID, identityv1.IdentityType_IDENTITY_TYPE_AGENT))
+		require.True(t, hasIdentityType(batchResp.Entries, thirdID, identityv1.IdentityType_IDENTITY_TYPE_AGENT_INSTANCE))
 	})
 
 	t.Run("NegativePaths", func(t *testing.T) {


### PR DESCRIPTION
## Summary

- Add `agent_instance` identity type mapping using API PR #157 (`IDENTITY_TYPE_AGENT_INSTANCE = 6`).
- Add nickname `instance_suffix` storage, uniqueness, resolution, and batch-read support.
- Parse and resolve `@nickname#suffix` handles at the Identity boundary.
- Validate suffix usage: required for `agent_instance`, rejected for non-instance identities.
- Update CI/E2E codegen to use the dependent API branch until #157 is merged.

## Migration

- `migrations/0004_agent_instance_nicknames.sql`
  - Adds `org_nicknames.instance_suffix`.
  - Replaces unique org nickname index with `(organization_id, nickname, COALESCE(instance_suffix, ''))` full-handle uniqueness.

## Test & Lint Summary

Commands run:

```bash
/root/go/bin/buf generate https://github.com/agynio/api.git#branch=noa/issue-161-identity-foundation --path proto/agynio/api/identity/v1 --path proto/agynio/api/authorization/v1
go test -count=1 ./...
go vet ./...
go build ./...
go test -count=1 -tags e2e ./test/e2e -run '^$'
git diff --check
```

Results:

- Unit/package tests: 13 passed / 0 failed / 0 skipped in `internal/server`; other packages had no test files.
- E2E compile check: 0 run / 0 failed / 0 skipped (`-run '^$'`, used to verify e2e test compilation without cluster services).
- Lint/static validation: `go vet ./...` passed with no errors.
- Build: `go build ./...` passed.
- Whitespace check: `git diff --check` passed.

E2E note:

- Full `devspace run test-e2e` was not completed locally because this workspace lacks DevSpace/Kubernetes setup and downloading the DevSpace binary repeatedly timed out over a very slow GitHub transfer. The e2e package was compile-checked locally with generated sources.

Depends on agynio/api#157.

Part of agynio/architecture#161.