### PR TITLE
chore: remove the ArgoCD sync dance

### DIFF
--- a/devspace.yaml
+++ b/devspace.yaml
@@ -183,8 +183,6 @@ dev:
         logs:
           enabled: true
           lastLines: 200
-    ports:
-      - port: "50051"
 
   e2e-runner:
     namespace: ${IDENTITY_NAMESPACE}

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -5,26 +5,6 @@ vars:
   E2E_IMAGE: ghcr.io/agynio/devcontainer-go:1
 
 functions:
-  disable_argocd_sync: |-
-    if kubectl get application identity -n argocd >/dev/null 2>&1; then
-      echo "Disabling ArgoCD auto-sync for identity..."
-      kubectl patch application identity -n argocd \
-        --type merge \
-        -p '{"spec":{"syncPolicy":{"automated":null}}}'
-      echo "ArgoCD auto-sync disabled."
-    else
-      echo "WARNING: ArgoCD Application 'identity' not found in argocd namespace."
-    fi
-  restore_argocd_sync: &restore_argocd_sync |-
-    if kubectl get application identity -n argocd >/dev/null 2>&1; then
-      echo "Re-enabling ArgoCD auto-sync for identity..."
-      kubectl patch application identity -n argocd \
-        --type merge \
-        -p '{"spec":{"syncPolicy":{"automated":{"prune":true,"selfHeal":true}}}}'
-      echo "ArgoCD auto-sync restored."
-    else
-      echo "WARNING: ArgoCD Application 'identity' not found in argocd namespace."
-    fi
   patch_deployment: |-
     echo "Patching identity deployment for DevSpace..."
     kubectl patch deployment identity -n ${IDENTITY_NAMESPACE} --type strategic --patch "$(cat <<'EOF'
@@ -108,7 +88,6 @@ pipelines:
         short: w
         description: "Keep DevSpace running and stream logs"
     run: |-
-      disable_argocd_sync
       patch_deployment
       if [ "$(get_flag "watch")" == "true" ]; then
         start_dev --disable-pod-replace identity
@@ -146,13 +125,6 @@ pipelines:
       exit $EXIT_CODE
 
 hooks:
-  - name: restore-argocd-auto-sync
-    events:
-      - after:dev:identity
-    command: bash
-    args:
-      - -c
-      - *restore_argocd_sync
 
 dev:
   identity:

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -159,7 +159,6 @@ dev:
     namespace: ${IDENTITY_NAMESPACE}
     labelSelector:
       app.kubernetes.io/name: identity
-      app.kubernetes.io/instance: identity
     containers:
       identity:
         container: identity


### PR DESCRIPTION
ArgoCD went away with bootstrap. Disabling its auto-sync before a source deploy and restoring it after has had nothing to disable or restore since the platform moved to the VM — every run printed `WARNING: ArgoCD Application not found in argocd namespace` and carried on.

Removes the `disable_argocd_sync` / `restore_argocd_sync` functions, their call sites, the `restore-argocd` pipeline and the `after:dev` hook.

Part of removing the E2E workflow’s build-time source patches: three of them existed only to inject a "skip the ArgoCD restore in CI" branch into this file.