### PR TITLE
Gate the nickname lookup on organization membership

### DIFF
--- a/devspace.yaml
+++ b/devspace.yaml
@@ -183,8 +183,6 @@ dev:
         logs:
           enabled: true
           lastLines: 200
-    ports:
-      - port: "50051"
 
   e2e-runner:
     namespace: ${IDENTITY_NAMESPACE}

--- a/internal/server/nicknames.go
+++ b/internal/server/nicknames.go
@@ -164,12 +164,16 @@ func (s *Server) BatchGetNicknames(ctx context.Context, req *identityv1.BatchGet
 		return nil, status.Errorf(codes.InvalidArgument, "organization_id: %v", err)
 	}
 
-	allowed, err := s.checkPermission(ctx, callerID, "can_view_threads", organizationID)
+	// Membership, not can_view_threads: that resolves to owner-or-cluster-admin,
+	// so no ordinary member of the organization could read its handles -- nor
+	// could an agent instance, which is what leaves a raw identity id in front
+	// of the model and "unknown participant" in the chat UI.
+	allowed, err := s.checkPermission(ctx, callerID, "member", organizationID)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "authorization check: %v", err)
 	}
 	if !allowed {
-		return nil, status.Error(codes.PermissionDenied, "missing permission to view thread nicknames")
+		return nil, status.Error(codes.PermissionDenied, "not a member of the organization")
 	}
 
 	identityIDs := req.GetIdentityIds()

--- a/internal/server/nicknames_test.go
+++ b/internal/server/nicknames_test.go
@@ -104,7 +104,9 @@ func TestBatchGetNicknamesOmitsMissing(t *testing.T) {
 	require.Equal(t, "runner", response.Entries[0].GetNickname())
 
 	require.NotNil(t, auth.lastRequest)
-	require.Equal(t, "can_view_threads", auth.lastRequest.GetTupleKey().GetRelation())
+	// Membership: can_view_threads is owner-or-cluster-admin, so no ordinary
+	// member of the organization could read its handles.
+	require.Equal(t, "member", auth.lastRequest.GetTupleKey().GetRelation())
 	require.Equal(t, fmt.Sprintf("%s%s", identityObjectPrefix, callerID.String()), auth.lastRequest.GetTupleKey().GetUser())
 	require.Equal(t, fmt.Sprintf("%s%s", organizationObjectPrefix, organizationID.String()), auth.lastRequest.GetTupleKey().GetObject())
 }


### PR DESCRIPTION
`BatchGetNicknames` was gated on `can_view_threads`, which is `owner or admin from cluster`. So no ordinary member of an organization could read its handles — and neither could an agent instance resolving who wrote to it:

```
missing permission to view thread nicknames
```

Membership is the right gate for reading handles within an org, and it is one an instance already holds. This also unblocks the chat UI, which renders agents as "(unknown participant)".

Supersedes the unidentified-caller path I proposed in #16 — no new trust surface needed.