### PR TITLE
Generate from the published API, and provision E2E on the VM

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Provision cluster
-        uses: agynio/bootstrap/.github/actions/provision@main
+        uses: agynio/e2e/.github/actions/provision-vm@main
 
       - name: Setup DevSpace
         uses: agynio/e2e/.github/actions/setup-devspace@main
@@ -39,7 +39,7 @@ jobs:
           version: 1.66.0
 
       - name: Prepare generated sources
-        run: buf generate https://github.com/agynio/api.git#branch=noa/issue-161-identity-foundation --path proto/agynio/api/identity/v1 --path proto/agynio/api/authorization/v1
+        run: buf generate buf.build/agynio/api --path agynio/api/identity/v1 --path agynio/api/authorization/v1
 
       - name: Build source binary for DevSpace
         run: |

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -1,7 +1,7 @@
 version: v2beta1
 
 vars:
-  IDENTITY_NAMESPACE: platform
+  IDENTITY_NAMESPACE: agyn-platform
   E2E_IMAGE: ghcr.io/agynio/devcontainer-go:1
 
 functions:


### PR DESCRIPTION
Three things kept this red.

**The generated sources came from a stale branch.** E2E generated from `https://github.com/agynio/api.git#branch=noa/issue-161-identity-foundation`, last touched 2026-07-15 and 32 commits behind main. `IDENTITY_TYPE_PLATFORM` landed after it, so the build died on a symbol CI compiles against every run:

```
internal/server/converter.go:27:21: undefined: identityv1.IdentityType_IDENTITY_TYPE_PLATFORM
```

It now generates from `buf.build/agynio/api`, the source `ci.yml` already uses.

**Provisioning.** `run-tests` reads `AGYN_API_TOKEN` from the environment; only the VM provisioner exports it. The bootstrap action left Terraform state behind instead.

**Namespace.** DevSpace follows the install to `agyn-platform`, which it moved to on 2026-08-09.

Depends on agynio/e2e#255.