### PR TITLE
Add DeleteOrganizationResources

### DIFF
--- a/charts/identity/Chart.yaml
+++ b/charts/identity/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: identity
 description: Helm chart for deploying the IdentityService gRPC server.
 type: application
-version: 0.1.0
-appVersion: 0.1.0
+version: 0.2.0
+appVersion: 0.2.0
 home: https://github.com/agynio/identity
 sources:
   - https://github.com/agynio/identity

--- a/charts/identity/templates/authorization-policy.yaml
+++ b/charts/identity/templates/authorization-policy.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.internalAuthorizationPolicy.enabled }}
+{{- $namespace := .Release.Namespace }}
+# DeleteOrganizationResources is one step of the organization teardown. It has
+# no caller identity to authorize, so who may reach it at all is settled here.
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+  name: {{ .Release.Name }}-internal-identity
+  labels:
+    app.kubernetes.io/name: {{ include "service-base.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "service-base.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  action: DENY
+  rules:
+    - from:
+        - source:
+            notPrincipals:
+{{- range .Values.internalAuthorizationPolicy.serviceAccounts }}
+              - "cluster.local/ns/{{ .namespace | default $namespace }}/sa/{{ .name }}"
+{{- end }}
+      to:
+        - operation:
+            methods:
+              - POST
+            paths:
+              - /agynio.api.identity.v1.IdentityService/DeleteOrganizationResources
+{{- end }}

--- a/charts/identity/values.yaml
+++ b/charts/identity/values.yaml
@@ -159,3 +159,9 @@ metrics:
         path: /metrics
         interval: ""
         scrapeTimeout: ""
+
+internalAuthorizationPolicy:
+  enabled: true
+  serviceAccounts:
+    - name: organizations
+      namespace: ""

--- a/internal/server/nicknames.go
+++ b/internal/server/nicknames.go
@@ -377,3 +377,22 @@ func (s *Server) authorizeNicknameRead(ctx context.Context, callerID uuid.UUID, 
 	}
 	return nil
 }
+
+// DeleteOrganizationResources removes the organization's nicknames. It is
+// internal: Istio settles who may call it, so there is no permission check and
+// no caller identity to check against. Step 8 of the organization teardown,
+// last because the identities that held these nicknames are deleted by the
+// services that registered them, in the steps above.
+//
+// Idempotent: the delete is unconditional, so a retried step finds nothing to
+// remove and still succeeds.
+func (s *Server) DeleteOrganizationResources(ctx context.Context, req *identityv1.DeleteOrganizationResourcesRequest) (*identityv1.DeleteOrganizationResourcesResponse, error) {
+	organizationID, err := parseUUID(req.GetOrganizationId())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "organization_id: %v", err)
+	}
+	if err := s.store.RemoveOrganizationNicknames(ctx, organizationID); err != nil {
+		return nil, status.Errorf(codes.Internal, "remove organization nicknames: %v", err)
+	}
+	return &identityv1.DeleteOrganizationResourcesResponse{}, nil
+}

--- a/internal/server/nicknames_test.go
+++ b/internal/server/nicknames_test.go
@@ -50,6 +50,8 @@ type fakeStore struct {
 	lastInstanceSuffix *string
 	resolution         store.NicknameResolution
 	registerErr        error
+	removedOrgs        []uuid.UUID
+	removeOrgErr       error
 }
 
 func (f *fakeStore) RegisterIdentity(context.Context, uuid.UUID, int16) error {
@@ -91,6 +93,14 @@ func (f *fakeStore) ResolveNickname(_ context.Context, _ uuid.UUID, nickname str
 	f.lastNickname = nickname
 	f.lastInstanceSuffix = instanceSuffix
 	return f.resolution, nil
+}
+
+func (f *fakeStore) RemoveOrganizationNicknames(_ context.Context, organizationID uuid.UUID) error {
+	if f.removeOrgErr != nil {
+		return f.removeOrgErr
+	}
+	f.removedOrgs = append(f.removedOrgs, organizationID)
+	return nil
 }
 
 func (f *fakeStore) BatchGetNicknames(_ context.Context, organizationID uuid.UUID, identityIDs []uuid.UUID) (map[uuid.UUID]store.NicknameEntry, error) {
@@ -305,4 +315,30 @@ func TestBatchGetNicknamesReturnsInstanceSuffix(t *testing.T) {
 	require.Len(t, response.Entries, 1)
 	require.Equal(t, "bob", response.Entries[0].GetNickname())
 	require.Equal(t, instanceSuffix, response.Entries[0].GetInstanceSuffix())
+}
+
+func TestDeleteOrganizationResourcesRemovesNicknames(t *testing.T) {
+	organizationID := uuid.New()
+	fake := &fakeStore{}
+	server := New(fake, &fakeAuthClient{})
+
+	req := &identityv1.DeleteOrganizationResourcesRequest{OrganizationId: organizationID.String()}
+	// Internal RPC: no identity in the context, and none required.
+	_, err := server.DeleteOrganizationResources(context.Background(), req)
+	require.NoError(t, err)
+
+	// The cascade retries a step it is unsure finished, so a second call has to
+	// succeed on the now-empty organization rather than report NotFound the way
+	// RemoveNickname would.
+	_, err = server.DeleteOrganizationResources(context.Background(), req)
+	require.NoError(t, err)
+	require.Equal(t, []uuid.UUID{organizationID, organizationID}, fake.removedOrgs)
+}
+
+func TestDeleteOrganizationResourcesRejectsInvalidOrganizationID(t *testing.T) {
+	server := New(&fakeStore{}, &fakeAuthClient{})
+	_, err := server.DeleteOrganizationResources(context.Background(), &identityv1.DeleteOrganizationResourcesRequest{
+		OrganizationId: "not-a-uuid",
+	})
+	require.Equal(t, codes.InvalidArgument, status.Code(err))
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -22,6 +22,7 @@ type identityStore interface {
 	RemoveNickname(context.Context, uuid.UUID, uuid.UUID, *uuid.UUID) error
 	ResolveNickname(context.Context, uuid.UUID, string, *string) (store.NicknameResolution, error)
 	BatchGetNicknames(context.Context, uuid.UUID, []uuid.UUID) (map[uuid.UUID]store.NicknameEntry, error)
+	RemoveOrganizationNicknames(context.Context, uuid.UUID) error
 }
 
 type authorizationChecker interface {

--- a/internal/store/nicknames.go
+++ b/internal/store/nicknames.go
@@ -63,6 +63,14 @@ func (s *Store) RemoveNickname(ctx context.Context, organizationID uuid.UUID, id
 	return nil
 }
 
+// RemoveOrganizationNicknames drops every nickname held in the organization.
+// Unlike RemoveNickname it does not report an empty result as NotFound: the
+// teardown step it serves is retried, and finding nothing left is success.
+func (s *Store) RemoveOrganizationNicknames(ctx context.Context, organizationID uuid.UUID) error {
+	_, err := s.pool.Exec(ctx, `DELETE FROM org_nicknames WHERE organization_id = $1`, organizationID)
+	return err
+}
+
 func (s *Store) ResolveNickname(ctx context.Context, organizationID uuid.UUID, nickname string, instanceSuffix *string) (NicknameResolution, error) {
 	var resolution NicknameResolution
 	var installationID pgtype.UUID


### PR DESCRIPTION
Step 8 of the [organization teardown](https://github.com/agynio/architecture/blob/main/architecture/organizations.md#teardown-order): the `org_nicknames` the organization held. Last in the order, because the identities those nicknames named are deleted by the services that registered them, in the steps above.

`RemoveOrganizationNicknames` deliberately does not report an empty result as `NotFound` the way `RemoveNickname` does — the step is retried, and finding nothing left is success rather than a missing row.

Internal RPC — no OpenFGA check and no caller identity, gated by a new Istio `AuthorizationPolicy` admitting only the `organizations` ServiceAccount.

Chart bumped to 0.2.0 for the new template.

Part of [organization settings and deletion](https://github.com/agynio/architecture/blob/main/changes/2026-08-12-organization-settings.md).